### PR TITLE
Resolve DDEV "version" obsolete notices

### DIFF
--- a/.ddev/docker-compose.selenium-chrome.yaml
+++ b/.ddev/docker-compose.selenium-chrome.yaml
@@ -4,7 +4,6 @@
 #
 # This file comes from https://github.com/ddev/ddev-selenium-standalone-chrome
 #
-version: '3.6'
 services:
   selenium-chrome:
     image: seleniarm/standalone-chromium:4.1.4-20220429

--- a/.ddev/docker-compose.solr.yaml
+++ b/.ddev/docker-compose.solr.yaml
@@ -23,8 +23,6 @@
 #   accessed at the URL: http://solr:8983/solr/dev (inside web container)
 #   or at http://myproject.ddev.site:8983/solr/dev (on the host)
 
-version: '3.6'
-
 services:
   solr:
     # Name of container using standard ddev convention


### PR DESCRIPTION
Using DDEV version: ddev version v1.24.4

Cloning and running `ddev start` outputs these warnings about version attribute. This PR removes them.


time="2025-04-29T08:51:17-04:00" level=warning msg="/Users/ben/projects/drupal.org/domain-ddev/.ddev/docker-compose.selenium-chrome.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion" 
time="2025-04-29T08:51:17-04:00" level=warning msg="/Users/ben/projects/drupal.org/domain-ddev/.ddev/docker-compose.solr.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion" 